### PR TITLE
Rate-limiting mechanism

### DIFF
--- a/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -19,9 +19,11 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.RateLimiting;
 
 namespace Booker.Areas.Identity.Pages.Account
 {
+    [EnableRateLimiting("IpRateLimit")]
     public class RegisterModel : PageModel
     {
         private readonly SignInManager<User> _signInManager;

--- a/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -128,12 +128,22 @@ namespace Booker.Areas.Identity.Pages.Account
                 {
                     _logger.LogInformation("Użytkownik utworzył nowe konto.");
 
-                    var userId = await _userManager.GetUserIdAsync(user);                    
-                                      
+                    var userId = await _userManager.GetUserIdAsync(user);
+                    var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                    code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+                    var callbackUrl = Url.Page(
+                        "/Account/ConfirmEmail",
+                        pageHandler: null,
+                        values: new { area = "Identity", userId = userId, code = code, returnUrl = returnUrl },
+                        protocol: Request.Scheme);
+
+                    await _emailSender.SendEmailAsync(Input.Email, "Potwierdź swój e-mail",
+                        $"Proszę potwierdź swoje konto klikając w ten <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>link</a>.");
+
 
                     if (_userManager.Options.SignIn.RequireConfirmedAccount)
                     {
-                        return RedirectToPage("RegisterConfirmation", new { userName = Input.UserName, email = Input.Email, returnUrl = returnUrl });
+                        return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
                     }
                     else
                     {

--- a/Booker/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
+++ b/Booker/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml
@@ -5,19 +5,7 @@
 }
 
 <h1>@ViewData["Title"]</h1>
-@{
-    if (@Model.DisplayConfirmAccountLink)
-    {
-<p>
-    This app does not currently have a real email sender registered, see <a href="https://aka.ms/aspaccountconf">these docs</a> for how to configure a real email sender.
-    Normally this would be emailed: <a id="confirm-link" href="@Model.EmailConfirmationUrl">Click here to confirm your account</a>
-</p>
-    }
-    else
-    {
-<p>
-        Please check your email to confirm your account.
-</p>
-    }
-}
 
+<p>
+    Please check your email to confirm your account.
+</p>

--- a/Booker/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/RegisterConfirmation.cshtml.cs
@@ -19,60 +19,14 @@ namespace Booker.Areas.Identity.Pages.Account
     [AllowAnonymous]
     public class RegisterConfirmationModel : PageModel
     {
-        private readonly UserManager<User> _userManager;
-        private readonly IEmailSender _sender;
-
-        public RegisterConfirmationModel(UserManager<User> userManager, IEmailSender sender)
+        public RegisterConfirmationModel()
         {
-            _userManager = userManager;
-            _sender = sender;
+
         }
 
-        /// <summary>
-        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public string Email { get; set; }
-
-        /// <summary>
-        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public bool DisplayConfirmAccountLink { get; set; }
-
-        /// <summary>
-        ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public string EmailConfirmationUrl { get; set; }
-
-        public async Task<IActionResult> OnGetAsync(string userName, string email, string returnUrl = null)
+        public void OnGet(string email, string returnUrl = null)
         {
-            if (userName == null)
-            {
-                return RedirectToPage("/Index");
-            }
-            returnUrl = returnUrl ?? Url.Content("~/");
-
-            var user = await _userManager.FindByNameAsync(userName);
-            if (user == null)
-            {
-                return NotFound($"Unable to load user: '{userName}'.");
-            }
-
-            var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-
-            var callbackUrl = Url.Page(
-                        "/Account/ConfirmEmail",
-                        pageHandler: null,
-                        values: new { area = "Identity", userId = user.Id, code = code, returnUrl = returnUrl },
-                        protocol: Request.Scheme);
-
-            await _sender.SendEmailAsync(email, "Potwierdź swój e-mail",
-                      $"Proszę potwierdź swoje konto klikając w ten <a href='{HtmlEncoder.Default.Encode(callbackUrl)}'>link</a>.");
-
-            return Page();
+            
         }
     }
 }

--- a/Booker/Program.cs
+++ b/Booker/Program.cs
@@ -1,14 +1,17 @@
-using Microsoft.Extensions.Hosting.Internal;
-using Microsoft.EntityFrameworkCore;
-using Booker.Data;
-using System.Globalization;
-using Serilog;
-using Microsoft.AspNetCore.Identity;
-using Booker.Services;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Configuration;
-using System.Net;
 using Booker.Areas.Identity.Utilities;
+using Booker.Data;
+using Booker.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Hosting.Internal;
+using Serilog;
+using System.Configuration;
+using System.Globalization;
+using System.Net;
+using System.Threading.RateLimiting;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,6 +43,7 @@ builder.Host.UseSerilog();
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddBookerServices(configuration);
+builder.Services.AddRateLimitPolicies();
 
 builder.Services.AddDbContext<DataContext>(options =>
 {
@@ -80,6 +84,7 @@ app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();
+app.UseRateLimiter();
 
 app.MapRazorPages();
 

--- a/Booker/Services/StartupUtilities.cs
+++ b/Booker/Services/StartupUtilities.cs
@@ -4,6 +4,7 @@ using Booker.Data;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using System.Threading.RateLimiting;
 using Azure.Storage.Blobs;
 
 namespace Booker.Services
@@ -19,6 +20,52 @@ namespace Booker.Services
             services.AddSingleton<IEmailSender, SendMailSvc>();
             
             return services;
+        }
+
+        public static IServiceCollection AddRateLimitPolicies(this IServiceCollection services)
+        {
+            services.AddRateLimiter(options =>
+            {
+                options.RejectionStatusCode = 429;
+
+                options.AddPolicy("IpRateLimit", context => {
+                    if (context.Request.Method == HttpMethods.Get ||
+                        context.Request.Method == HttpMethods.Head ||
+                        context.Request.Method == HttpMethods.Options
+                    )
+                    {
+                        return RateLimitPartition.GetNoLimiter("");
+                    }
+
+                    return IpRateLimit(context);
+
+                });
+
+                options.AddPolicy("IpRateLimitAllMethods", context => {
+                    return IpRateLimit(context);
+                });
+            });
+
+            return services;
+        }
+
+        private static RateLimitPartition<string> IpRateLimit(HttpContext ctx)
+        {
+            var ipAddress = ctx.Connection.RemoteIpAddress?.ToString();
+
+            if (ipAddress == null)
+            {
+                return RateLimitPartition.GetNoLimiter(""); // No IP address, no rate limiting
+            }
+
+            return RateLimitPartition.GetFixedWindowLimiter(ipAddress,
+                factory: partition => new FixedWindowRateLimiterOptions
+                {
+                    AutoReplenishment = true,
+                    PermitLimit = 10,
+                    QueueLimit = 0, // No queueing, reject requests immediately
+                    Window = TimeSpan.FromMinutes(1)
+                });
         }
 
         public static async Task<WebApplication> MigrateDatabaseAsync(this WebApplication app, IConfiguration configuration)


### PR DESCRIPTION
This implements a simple IP address-based rate limiting. We may use a better mechanism in the future, but this one should do for now.

Also, I've moved the email sending action back to the register POST handler. This solves the problem of it being in a GET method and is, in my opinion, the simplest solution, because sending the email is essential to the registration process.