### PR TITLE
Seeding refactor

### DIFF
--- a/Booker/Data/DataContext.cs
+++ b/Booker/Data/DataContext.cs
@@ -26,10 +26,6 @@ namespace Booker.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-            var userIdGenerator = GenerateAscendingIntegers().GetEnumerator();
-            var itemIdGenerator = GenerateAscendingIntegers().GetEnumerator();
-            var userSequenceGenerator = GenerateEndlessLoop(1, 6).GetEnumerator();
-            var rand = new Random();
 
             modelBuilder.Entity<Subject>().HasData(SeedData.Subjects);
 
@@ -48,51 +44,6 @@ namespace Booker.Data
                         bg.HasData(bookGrades);
                     });
             });
-
-
-
-            var users = new List<User>();
-
-            for (int i = 0; i < 5; i++)
-            {
-                users.Add(
-                    new User
-                    { 
-                        Id = GetNextId(userIdGenerator),
-                        Email = "user" + GetCurrentId(userIdGenerator) + "@gmail.com",
-                        UserName = "user" + GetCurrentId(userIdGenerator),
-                        School = "Śl.TZN",
-                        Photo = "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"
-                    }
-                );
-            }
-
-            modelBuilder.Entity<User>().HasData(users);
-
-
-
-            var items = new List<Item>();
-
-            for (int i = 0; i < 50; i++)
-            {
-                items.Add(
-                    new Item
-                    {
-                        Id = GetNextId(itemIdGenerator),
-                        BookId = rand.Next(1, SeedData.Books.Count),
-                        Book = null!, // Book will be set by the database
-                        UserId = GetNextId(userSequenceGenerator),
-                        User = null!, // User will be set by the database
-                        Price = rand.Next(140, 600) / 7M,
-                        DateTime = DateTime.Now,
-                        Description = "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.",
-                        State = "bardzo dobry",
-                        Photo = "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-                    }
-                );
-            }
-
-            modelBuilder.Entity<Item>().HasData(items);
         }
 
         public static IEnumerable<int> GenerateAscendingIntegers(int start = 1, int end = 1000)
@@ -118,11 +69,6 @@ namespace Booker.Data
         {
             if (!idGenerator.MoveNext())
                 throw new System.InvalidOperationException("Not enough IDs in the generator.");
-            return idGenerator.Current;
-        }
-
-        private static int GetCurrentId(IEnumerator<int> idGenerator)
-        {
             return idGenerator.Current;
         }
 

--- a/Booker/Migrations/20250620125547_SeedRefactor.Designer.cs
+++ b/Booker/Migrations/20250620125547_SeedRefactor.Designer.cs
@@ -4,6 +4,7 @@ using Booker.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Booker.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20250620125547_SeedRefactor")]
+    partial class SeedRefactor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Booker/Migrations/20250620125547_SeedRefactor.cs
+++ b/Booker/Migrations/20250620125547_SeedRefactor.cs
@@ -263,6 +263,11 @@ namespace Booker.Migrations
                 keyColumn: "Id",
                 keyValue: 50);
 
+            migrationBuilder.Sql(
+                "DBCC CHECKIDENT('Items', RESEED, 0);" +
+                "DBCC CHECKIDENT('Items', RESEED, 0);"
+            );
+
             migrationBuilder.DeleteData(
                 table: "AspNetUsers",
                 keyColumn: "Id",
@@ -287,6 +292,11 @@ namespace Booker.Migrations
                 table: "AspNetUsers",
                 keyColumn: "Id",
                 keyValue: 5);
+
+            migrationBuilder.Sql(
+                "DBCC CHECKIDENT('AspNetUsers', RESEED, 0);" +
+                "DBCC CHECKIDENT('AspNetUsers', RESEED, 0);"
+            );
         }
 
         /// <inheritdoc />
@@ -303,6 +313,10 @@ namespace Booker.Migrations
                     { 4, 0, "90c50ca1-8852-4413-a0dd-a9f1b4c85ac7", "user4@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user4" },
                     { 5, 0, "c76fee65-29c9-4db1-b5bd-dbac57d21e6a", "user5@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user5" }
                 });
+
+            migrationBuilder.Sql(
+                "DBCC CHECKIDENT('AspNetUsers', RESEED);"
+            );
 
             migrationBuilder.InsertData(
                 table: "Items",
@@ -360,6 +374,10 @@ namespace Booker.Migrations
                     { 49, 39, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6495), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 24.285714285714285714285714286m, "bardzo dobry", 4 },
                     { 50, 10, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6499), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 79m, "bardzo dobry", 5 }
                 });
+
+            migrationBuilder.Sql(
+                "DBCC CHECKIDENT('Items', RESEED);"
+            );
         }
     }
 }

--- a/Booker/Migrations/20250620125547_SeedRefactor.cs
+++ b/Booker/Migrations/20250620125547_SeedRefactor.cs
@@ -1,0 +1,365 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Booker.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedRefactor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 9);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 10);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 11);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 12);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 13);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 14);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 15);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 16);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 17);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 18);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 19);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 20);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 21);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 22);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 23);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 24);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 25);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 26);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 27);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 28);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 29);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 30);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 31);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 32);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 33);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 34);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 35);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 36);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 37);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 38);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 39);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 40);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 41);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 42);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 43);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 44);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 45);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 46);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 47);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 48);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 49);
+
+            migrationBuilder.DeleteData(
+                table: "Items",
+                keyColumn: "Id",
+                keyValue: 50);
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "AspNetUsers",
+                keyColumn: "Id",
+                keyValue: 5);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "AspNetUsers",
+                columns: new[] { "Id", "AccessFailedCount", "ConcurrencyStamp", "Email", "EmailConfirmed", "LockoutEnabled", "LockoutEnd", "NormalizedEmail", "NormalizedUserName", "PasswordHash", "PhoneNumber", "PhoneNumberConfirmed", "Photo", "School", "SecurityStamp", "TwoFactorEnabled", "UserName" },
+                values: new object[,]
+                {
+                    { 1, 0, "ed35d162-1fcd-4bd0-9c5d-91eea43d742a", "user1@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user1" },
+                    { 2, 0, "3ec5d9f6-ca4e-4011-9e9a-d9720ed87ded", "user2@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user2" },
+                    { 3, 0, "9a5ae8da-9d64-443a-ade0-fe6bb552c61b", "user3@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user3" },
+                    { 4, 0, "90c50ca1-8852-4413-a0dd-a9f1b4c85ac7", "user4@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user4" },
+                    { 5, 0, "c76fee65-29c9-4db1-b5bd-dbac57d21e6a", "user5@gmail.com", false, false, null, null, null, null, null, false, "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png", "Śl.TZN", null, false, "user5" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Items",
+                columns: new[] { "Id", "BookId", "DateTime", "Description", "Photo", "Price", "State", "UserId" },
+                values: new object[,]
+                {
+                    { 1, 23, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6182), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 59.428571428571428571428571429m, "bardzo dobry", 1 },
+                    { 2, 72, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6252), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 42.857142857142857142857142857m, "bardzo dobry", 2 },
+                    { 3, 39, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6259), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 42.428571428571428571428571429m, "bardzo dobry", 3 },
+                    { 4, 73, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6263), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 63m, "bardzo dobry", 4 },
+                    { 5, 72, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6267), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 38.428571428571428571428571429m, "bardzo dobry", 5 },
+                    { 6, 5, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6274), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 21.142857142857142857142857143m, "bardzo dobry", 1 },
+                    { 7, 39, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6278), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 50.142857142857142857142857143m, "bardzo dobry", 2 },
+                    { 8, 34, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6284), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 84.28571428571428571428571429m, "bardzo dobry", 3 },
+                    { 9, 78, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6288), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 83.85714285714285714285714286m, "bardzo dobry", 4 },
+                    { 10, 68, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6294), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 40.285714285714285714285714286m, "bardzo dobry", 5 },
+                    { 11, 49, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6299), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 56.285714285714285714285714286m, "bardzo dobry", 1 },
+                    { 12, 40, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6303), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 44.285714285714285714285714286m, "bardzo dobry", 2 },
+                    { 13, 48, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6308), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 28.428571428571428571428571429m, "bardzo dobry", 3 },
+                    { 14, 34, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6312), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 41.857142857142857142857142857m, "bardzo dobry", 4 },
+                    { 15, 48, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6316), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 67.571428571428571428571428571m, "bardzo dobry", 5 },
+                    { 16, 7, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6321), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 43.285714285714285714285714286m, "bardzo dobry", 1 },
+                    { 17, 73, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6326), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 64.857142857142857142857142857m, "bardzo dobry", 2 },
+                    { 18, 66, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6355), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 72.428571428571428571428571429m, "bardzo dobry", 3 },
+                    { 19, 50, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6360), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 74.571428571428571428571428571m, "bardzo dobry", 4 },
+                    { 20, 50, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6365), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 82.28571428571428571428571429m, "bardzo dobry", 5 },
+                    { 21, 29, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6370), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 32.857142857142857142857142857m, "bardzo dobry", 1 },
+                    { 22, 61, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6374), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 35.571428571428571428571428571m, "bardzo dobry", 2 },
+                    { 23, 19, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6378), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 23.285714285714285714285714286m, "bardzo dobry", 3 },
+                    { 24, 1, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6383), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 68.142857142857142857142857143m, "bardzo dobry", 4 },
+                    { 25, 48, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6388), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 75.142857142857142857142857143m, "bardzo dobry", 5 },
+                    { 26, 37, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6392), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 34.714285714285714285714285714m, "bardzo dobry", 1 },
+                    { 27, 56, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6397), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 53.142857142857142857142857143m, "bardzo dobry", 2 },
+                    { 28, 29, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6401), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 65.142857142857142857142857143m, "bardzo dobry", 3 },
+                    { 29, 75, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6405), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 29.714285714285714285714285714m, "bardzo dobry", 4 },
+                    { 30, 40, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6410), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 45.428571428571428571428571429m, "bardzo dobry", 5 },
+                    { 31, 8, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6415), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 72.571428571428571428571428571m, "bardzo dobry", 1 },
+                    { 32, 61, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6420), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 50.714285714285714285714285714m, "bardzo dobry", 2 },
+                    { 33, 26, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6424), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 76m, "bardzo dobry", 3 },
+                    { 34, 63, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6430), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 74.285714285714285714285714286m, "bardzo dobry", 4 },
+                    { 35, 8, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6435), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 33.428571428571428571428571429m, "bardzo dobry", 5 },
+                    { 36, 37, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6438), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 34m, "bardzo dobry", 1 },
+                    { 37, 17, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6441), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 85m, "bardzo dobry", 2 },
+                    { 38, 53, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6446), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 74.142857142857142857142857143m, "bardzo dobry", 3 },
+                    { 39, 20, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6451), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 45.142857142857142857142857143m, "bardzo dobry", 4 },
+                    { 40, 41, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6455), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 84.85714285714285714285714286m, "bardzo dobry", 5 },
+                    { 41, 66, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6460), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 43.285714285714285714285714286m, "bardzo dobry", 1 },
+                    { 42, 9, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6465), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 39.285714285714285714285714286m, "bardzo dobry", 2 },
+                    { 43, 71, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6468), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 51m, "bardzo dobry", 3 },
+                    { 44, 75, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6473), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 40.857142857142857142857142857m, "bardzo dobry", 4 },
+                    { 45, 46, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6477), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 36.428571428571428571428571429m, "bardzo dobry", 5 },
+                    { 46, 31, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6482), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 56.857142857142857142857142857m, "bardzo dobry", 1 },
+                    { 47, 10, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6486), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 57.142857142857142857142857143m, "bardzo dobry", 2 },
+                    { 48, 58, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6491), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 74.571428571428571428571428571m, "bardzo dobry", 3 },
+                    { 49, 39, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6495), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 24.285714285714285714285714286m, "bardzo dobry", 4 },
+                    { 50, 10, new DateTime(2025, 6, 14, 19, 59, 58, 431, DateTimeKind.Local).AddTicks(6499), "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.", "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D", 79m, "bardzo dobry", 5 }
+                });
+        }
+    }
+}

--- a/Booker/Program.cs
+++ b/Booker/Program.cs
@@ -99,4 +99,10 @@ if (app.Environment.IsDevelopment())
         string.Join("\n", endpointSources.SelectMany(source => source.Endpoints)));
 }
 await app.MigrateDatabaseAsync(configuration);
+
+if (app.Environment.IsDevelopment())
+{
+    await app.InitializeDatabaseAsync();
+}
+
 app.Run();

--- a/Booker/Services/DevDbInitializer.cs
+++ b/Booker/Services/DevDbInitializer.cs
@@ -1,0 +1,62 @@
+﻿using Booker.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Booker.Services
+{
+    public class DevDbInitializer
+    {
+        public static async Task Initialize(DataContext context, int itemsCount, int usersCount)
+        {
+            if (await context.Items.CountAsync() > itemsCount
+                && await context.Users.CountAsync() > usersCount)
+            {
+                return;
+            }
+
+            var lastUserId = await context.Users.AnyAsync()
+                ? await context.Users.MaxAsync(u => u.Id)
+                : 0;
+
+            var users = new List<User>();
+
+            for (int i = 1; i <= usersCount; i++)
+            {
+                users.Add(
+                    new User
+                    {
+                        Email = "user" + i + "@gmail.com",
+                        UserName = "user" + i,
+                        School = "Śl.TZN",
+                        Photo = "https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png"
+                    }
+                );
+            }
+
+            context.AddRange(users);
+            
+            var books = await context.Books.ToListAsync();
+            var rand = new Random();
+            var items = new List<Item>();
+            for (int i = 0; i < itemsCount; i++)
+            {
+                items.Add(
+                    new Item
+                    {
+                        Book = books[rand.Next(books.Count)],
+                        User = users[rand.Next(users.Count)],
+                        Price = rand.Next(140, 600) / 7M,
+                        DateTime = DateTime.Now.AddDays(-(rand.Next(7*24*60)/(24*60.0))), // random date within the last week
+                        Description = "Książka w dobrym stanie, prawie nie używana, nie zalana, rogi delikatnie zagięte, polecam kebab Zahir i pytam czy idziecie na sylwestra do zduniaka.",
+                        State = "bardzo dobry",
+                        Photo = "https://images.unsplash.com/photo-1517770413964-df8ca61194a6?q=80&w=1770&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                    }
+                );
+            }
+
+            items.Sort((x, y) => x.DateTime.CompareTo(y.DateTime));
+            context.AddRange(items);
+
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Booker/Services/StartupUtilities.cs
+++ b/Booker/Services/StartupUtilities.cs
@@ -83,7 +83,7 @@ namespace Booker.Services
                     var migrator = dbContext.Database.GetService<IMigrator>();
 
 
-                if (clearDatabase)
+                    if (clearDatabase)
                     {
                         logger.LogWarning("WARNING: ClearDatabaseOnStartup is set to true. We will try to revert all migrations, and apply them again");
 

--- a/Booker/Services/StartupUtilities.cs
+++ b/Booker/Services/StartupUtilities.cs
@@ -83,7 +83,7 @@ namespace Booker.Services
                     var migrator = dbContext.Database.GetService<IMigrator>();
 
 
-                    if (clearDatabase)
+                if (clearDatabase)
                     {
                         logger.LogWarning("WARNING: ClearDatabaseOnStartup is set to true. We will try to revert all migrations, and apply them again");
 
@@ -110,6 +110,23 @@ namespace Booker.Services
                 }
             
 
+            return app;
+        }
+
+        public static async Task<WebApplication> InitializeDatabaseAsync(this WebApplication app, int itemsCount = 50, int usersCount = 5)
+        {
+            using var scope = app.Services.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<DataContext>();
+            var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+            try
+            {
+                await DevDbInitializer.Initialize(dbContext, itemsCount, usersCount);
+                logger.LogInformation("Database initialized with {ItemsCount} items and {UsersCount} users.", itemsCount, usersCount);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Something went wrong during database initialization.");
+            }
             return app;
         }
 


### PR DESCRIPTION
This moves random seed data (Items and Users) out of migrations, and into a new class `DevDbInitializer`, used only during development. Also, the primary keys are reseeded for this to work correctly.

Right now, test data won't be processed in every new migration. Ideally, it shouldn't be processed at all, but this requires editing existing migrations, so it will be tricky to do and may require dropping and recreating the production database.

Another idea I had is to seed `Items` and `Users` to a higher value, e.g. 1000 and 100, when we release a GA version. This will not only make the urls look a little bit better, but also free lower `User` values for internal use (admin accounts etc.)

closes #64 