### PR TITLE
Auto-open dropdown on mobile

### DIFF
--- a/Booker/Pages/Shared/_LoginPartial.cshtml
+++ b/Booker/Pages/Shared/_LoginPartial.cshtml
@@ -4,7 +4,7 @@
 @inject SignInManager<User> SignInManager
 @inject UserManager<User> UserManager
 
-<input type="checkbox" id="hamburger-btn">
+<input type="checkbox" id="hamburger-btn" hx-on:change="toggleHamburgerMenu(this)">
 <label for="hamburger-btn" aria-label="Menu"
        aria-controls="hamburger">
     <svg icon="menu-2" aria-hidden="true"></svg>

--- a/Booker/wwwroot/js/site.js
+++ b/Booker/wwwroot/js/site.js
@@ -90,6 +90,15 @@ function showSummary(event) {
     }
 }
 
+function toggleHamburgerMenu(check) {
+    const hamburger = document.getElementById('hamburger').querySelector('details');
+    if (check.checked) {
+        hamburger.setAttribute("open","");
+    } else {
+        hamburger.removeAttribute("open");
+    }
+}
+
 let v = new aspnetValidation.ValidationService();
 v.bootstrap({ watch: true });
 

--- a/Booker/wwwroot/scss/_hamburger.scss
+++ b/Booker/wwwroot/scss/_hamburger.scss
@@ -207,6 +207,10 @@ nav[role=navigation] > [role=list] {
             transform: scaleY(1);
             opacity: 1;
         }
+
+        details.dropdown[open] > summary::before {
+            display: none;
+        }
     }
 }
 


### PR DESCRIPTION
Dropdown menu should now open automatically on mobile and no longer restrict clicking around it while it's open. Desktop behavior is unaffected.

closes #76 