### PR TITLE
Fix translations & translate error page

### DIFF
--- a/Booker/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -47,8 +47,8 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
-            [EmailAddress(ErrorMessage = "Pole {0} nie jest prawidłowym adresem e-mail.")]
+            [Required]
+            [EmailAddress]
             [Display(Name = "E-mail")]
             public string Email { get; set; }
         }

--- a/Booker/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -67,7 +67,7 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [Display(Name = "Nazwa użytkownika / e-mail")]
             public string Email { get; set; }
 
@@ -75,7 +75,7 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [DataType(DataType.Password)]
             [Display(Name = "Hasło")]
             public string Password { get; set; }

--- a/Booker/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -53,16 +53,16 @@ namespace Booker.Areas.Identity.Pages.Account.Manage
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [DataType(DataType.Password)]
-            [Display(Name = "Current password")]
+            [Display(Name = "Obecne hasło")]
             public string OldPassword { get; set; }
 
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [StringLength(100, ErrorMessage = "{0} musi mieć co najmniej {2}, a maksymalnie {1} znaków.", MinimumLength = 6)]
             [DataType(DataType.Password)]
             [Display(Name = "Nowe hasło")]

--- a/Booker/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs
@@ -49,7 +49,7 @@ namespace Booker.Areas.Identity.Pages.Account.Manage
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [DataType(DataType.Password)]
             public string Password { get; set; }
         }

--- a/Booker/Areas/Identity/Pages/Account/Manage/Email.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Manage/Email.cshtml.cs
@@ -70,8 +70,8 @@ namespace Booker.Areas.Identity.Pages.Account.Manage
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
-            [EmailAddress(ErrorMessage = "Pole {0} nie jest prawidłowym adresem e-mail.")]
+            [Required]
+            [EmailAddress]
             [Display(Name = "Nowy email")]
             public string NewEmail { get; set; }
         }

--- a/Booker/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Manage/Index.cshtml.cs
@@ -56,7 +56,7 @@ namespace Booker.Areas.Identity.Pages.Account.Manage
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Phone(ErrorMessage = "Pole {0} nie jest prawidłowym numerem telefonu.")]
+            [Phone]
             [Display(Name = "Numer telefonu")]
             public string PhoneNumber { get; set; }
 

--- a/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -73,15 +73,15 @@ namespace Booker.Areas.Identity.Pages.Account
         /// </summary>
         public class InputModel
         {
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [Display(Name = "Nazwa użytkownika")]
             public string UserName { get; set; }
             /// <summary>
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
-            [EmailAddress(ErrorMessage = "Pole {0} nie jest prawidłowym adresem e-mail.")]
+            [Required]
+            [EmailAddress]
             [Display(Name = "E-mail")]
             public string Email { get; set; }
 
@@ -89,7 +89,7 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [StringLength(100, ErrorMessage = "{0} musi mieć co najmniej {2}, a maksymalnie {1} znaków.", MinimumLength = 6)]
             [DataType(DataType.Password)]
             [Display(Name = "Hasło")]

--- a/Booker/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/ResendEmailConfirmation.cshtml.cs
@@ -48,8 +48,8 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
-            [EmailAddress(ErrorMessage = "Pole {0} nie jest prawidłowym adresem e-mail.")]
+            [Required]
+            [EmailAddress]
             public string Email { get; set; }
         }
 

--- a/Booker/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -41,8 +41,8 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
-            [EmailAddress(ErrorMessage = "Pole {0} nie jest prawidłowym adresem e-mail.")]
+            [Required]
+            [EmailAddress]
             [Display(Name = "E-mail")]
             public string Email { get; set; }
 
@@ -50,7 +50,7 @@ namespace Booker.Areas.Identity.Pages.Account
             ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
-            [Required(ErrorMessage = "Pole {0} jest wymagane.")]
+            [Required]
             [StringLength(100, ErrorMessage = "{0} musi mieć co najmniej {2}, a maksymalnie {1} znaków.", MinimumLength = 6)]
             [DataType(DataType.Password)]
             [Display(Name = "Hasło")]

--- a/Booker/Areas/Identity/Utilities/ErrorDescriber.cs
+++ b/Booker/Areas/Identity/Utilities/ErrorDescriber.cs
@@ -4,26 +4,46 @@ namespace Booker.Areas.Identity.Utilities
 {
     public class ErrorDescriber : IdentityErrorDescriber
     {
-        public override IdentityError DefaultError() { return new IdentityError { Code = nameof(DefaultError), Description = $"Wystąpił nieanany błąd." }; }
+        public override IdentityError DefaultError() { return new IdentityError { Code = nameof(DefaultError), Description = "Wystąpił nieznany błąd." }; }
         public override IdentityError ConcurrencyFailure() { return new IdentityError { Code = nameof(ConcurrencyFailure), Description = "Błąd współbieżności, obiekt został zmodyfikowany." }; }
         public override IdentityError PasswordMismatch() { return new IdentityError { Code = nameof(PasswordMismatch), Description = "Nieprawidłowe hasło." }; }
         public override IdentityError InvalidToken() { return new IdentityError { Code = nameof(InvalidToken), Description = "Nieprawidłowy token." }; }
-        public override IdentityError LoginAlreadyAssociated() { return new IdentityError { Code = nameof(LoginAlreadyAssociated), Description = "Użytkownik o takiej nazwie już istnieje." }; }
-        public override IdentityError InvalidUserName(string? userName) { return new IdentityError { Code = nameof(InvalidUserName), Description = $"Nazwa użytkownika \"'{userName}'\" jest nieprawidłowa, może posiadać tylko znaki i cyfry." }; }
-        public override IdentityError InvalidEmail(string? email) { return new IdentityError { Code = nameof(InvalidEmail), Description = $"Email \"'{email}'\" jest nieprawidłowy." }; }
-        public override IdentityError DuplicateUserName(string userName) { return new IdentityError { Code = nameof(DuplicateUserName), Description = $"Nazwa użytkownika \"'{userName}'\" jest zajęta." }; }
-        public override IdentityError DuplicateEmail(string email) { return new IdentityError { Code = nameof(DuplicateEmail), Description = $"Adres \"'{email}'\" jest zajęty." }; }
-        public override IdentityError InvalidRoleName(string? role) { return new IdentityError { Code = nameof(InvalidRoleName), Description = $"Grupa \"'{role}'\" jest nieprawidłowa." }; }
-        public override IdentityError DuplicateRoleName(string role) { return new IdentityError { Code = nameof(DuplicateRoleName), Description = $"Nazwa grupy \"'{role}'\" jest zajęta." }; }
-        public override IdentityError UserAlreadyHasPassword() { return new IdentityError { Code = nameof(UserAlreadyHasPassword), Description = "Hasło użytkownika jest już ustawione." }; }
-        public override IdentityError UserLockoutNotEnabled() { return new IdentityError { Code = nameof(UserLockoutNotEnabled), Description = "Blokada nie jest ustawiona dla tego użytkownika." }; }
-        public override IdentityError UserAlreadyInRole(string role) { return new IdentityError { Code = nameof(UserAlreadyInRole), Description = $"Użytkownik ma już przypisaną grupę \"'{role}'\"." }; }
-        public override IdentityError UserNotInRole(string role) { return new IdentityError { Code = nameof(UserNotInRole), Description = $"Użytkownik nie należy do grupy \"'{role}'\"." }; }
-        public override IdentityError PasswordTooShort(int length) { return new IdentityError { Code = nameof(PasswordTooShort), Description = $"Hasło musi posiadać conajmniej {length} znaków." }; }
-        public override IdentityError PasswordRequiresNonAlphanumeric() { return new IdentityError { Code = nameof(PasswordRequiresNonAlphanumeric), Description = "Hasło musi posiadać przynajmniej jeden znak alfanumeryczny." }; }
-        public override IdentityError PasswordRequiresDigit() { return new IdentityError { Code = nameof(PasswordRequiresDigit), Description = "Hasło musi posiadać przynajmniej jedną cyfrę ('0'-'9')." }; }
-        public override IdentityError PasswordRequiresLower() { return new IdentityError { Code = nameof(PasswordRequiresLower), Description = "Hasło musi posiadać przynajmniej jedną małą literę ('a'-'z')." }; }
-        public override IdentityError PasswordRequiresUpper() { return new IdentityError { Code = nameof(PasswordRequiresUpper), Description = "Hasło musi posiadać przynajmniej jedną wielką literę ('A'-'Z')." }; }
-        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) { return new IdentityError { Code = nameof(PasswordRequiresNonAlphanumeric), Description = "Hasło musi posiadać przynajmniej jeden znak specjalny." }; }
+        public override IdentityError RecoveryCodeRedemptionFailed() { return new IdentityError { Code = nameof(RecoveryCodeRedemptionFailed), Description = "Realizacja kodu odzyskiwania nie powiodła się." }; }
+        public override IdentityError LoginAlreadyAssociated() { return new IdentityError { Code = nameof(LoginAlreadyAssociated), Description = "To konto zewnętrzne jest już przypisane do innego użytkownika." }; }
+        public override IdentityError InvalidUserName(string? userName) { return new IdentityError { Code = nameof(InvalidUserName), Description = $"Nazwa użytkownika \"{userName}\" jest nieprawidłowa, może zawierać tylko litery i cyfry." }; }
+        public override IdentityError InvalidEmail(string? email) { return new IdentityError { Code = nameof(InvalidEmail), Description = $"E-mail \"{email}\" jest nieprawidłowy." }; }
+        public override IdentityError DuplicateUserName(string userName) { return new IdentityError { Code = nameof(DuplicateUserName), Description = $"Nazwa użytkownika \"{userName}\" jest już zajęta." }; }
+        public override IdentityError DuplicateEmail(string email) { return new IdentityError { Code = nameof(DuplicateEmail), Description = $"E-mail \"{email}\" jest już zajęty." }; }
+        public override IdentityError InvalidRoleName(string? role) { return new IdentityError { Code = nameof(InvalidRoleName), Description = $"Nazwa roli \"'{role}'\" jest nieprawidłowa." }; }
+        public override IdentityError DuplicateRoleName(string role) { return new IdentityError { Code = nameof(DuplicateRoleName), Description = $"Nazwa roli \"{role}\" jest już zajęta." }; }
+        public override IdentityError UserAlreadyHasPassword() { return new IdentityError { Code = nameof(UserAlreadyHasPassword), Description = "Użytkownik ma już ustawione hasło." }; }
+        public override IdentityError UserLockoutNotEnabled() { return new IdentityError { Code = nameof(UserLockoutNotEnabled), Description = "Blokada nie jest włączona dla tego użytkownika." }; }
+        public override IdentityError UserAlreadyInRole(string role) { return new IdentityError { Code = nameof(UserAlreadyInRole), Description = $"Użytkownik ma już przypisaną rolę \"{role}\"." }; }
+        public override IdentityError UserNotInRole(string role) { return new IdentityError { Code = nameof(UserNotInRole), Description = $"Użytkownik nie ma przypisanej roli \"{role}\"." }; }
+        public override IdentityError PasswordTooShort(int length) { return new IdentityError { Code = nameof(PasswordTooShort), Description = $"Hasło musi mieć co najmniej {length} {(DoubleNumber(length) ? "znaki" : "znaków")}." }; }
+        public override IdentityError PasswordRequiresUniqueChars(int uniqueChars) { return new IdentityError { Code = nameof(PasswordRequiresUniqueChars), Description = $"Hasło musi zawierać co najmniej {uniqueChars} {(DoubleNumber(uniqueChars) ? "różne znaki" : "różnych znaków")}." }; }
+        public override IdentityError PasswordRequiresNonAlphanumeric() { return new IdentityError { Code = nameof(PasswordRequiresNonAlphanumeric), Description = "Hasło musi zawierać co najmniej jeden znak specjalny." }; }
+        public override IdentityError PasswordRequiresDigit() { return new IdentityError { Code = nameof(PasswordRequiresDigit), Description = "Hasło musi zawierać co najmniej jedną cyfrę (0-9)." }; }
+        public override IdentityError PasswordRequiresLower() { return new IdentityError { Code = nameof(PasswordRequiresLower), Description = "Hasło musi zawierać co najmniej jedną małą literę (a-z)." }; }
+        public override IdentityError PasswordRequiresUpper() { return new IdentityError { Code = nameof(PasswordRequiresUpper), Description = "Hasło musi zawierać co najmniej jedną wielką literę (A-Z)." }; }
+
+        // In Polish, different suffix is used between 2-4 and 5+ numbers (e.g. "2 znaki", "5 znaków").
+        // Of course, this description is an oversimplification.
+        private bool DoubleNumber(int number)
+        {
+            if (number < 2)
+                throw new ArgumentOutOfRangeException(nameof(number), "Number must be greater than 1.");
+
+            number %= 100;
+            if (number >= 10 && number <= 20)
+            {
+                return false; // 11, 12, 13, ..., 19
+            }
+            else
+            {
+                number %= 10;
+                return number >= 2 && number <= 4; // 2, 3, 4
+            }
+        }
     }
 }

--- a/Booker/Pages/Error.cshtml
+++ b/Booker/Pages/Error.cshtml
@@ -1,29 +1,20 @@
 ﻿@page
 @model ErrorModel
 @{
-    ViewData["Title"] = "Error";
+    ViewData["Title"] = "Błąd";
 }
 
-<hgroup class="error">
-    <h1>Error.</h1>
-    <h2>An error occurred while processing your request.</h2>
+<hgroup>
+    <h1>Błąd.</h1>
+    <h2>Wystąpił błąd podczas przetwarzania żądania.</h2>
 </hgroup>
 
 
 @if (Model.ShowRequestId)
 {
     <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+        <strong>Identyfikator żądania:</strong> <code>@Model.RequestId</code>
     </p>
 }
 
-<h3>Development Mode</h3>
-<p>
-    Swapping to the <strong>Development</strong> environment displays detailed information about the error that occurred.
-</p>
-<p>
-    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
-    It can result in displaying sensitive information from exceptions to end users.
-    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
-    and restarting the app.
-</p>
+@* TODO: add a contact email or other details *@

--- a/Booker/Program.cs
+++ b/Booker/Program.cs
@@ -14,6 +14,8 @@ using System.Globalization;
 using System.Net;
 using System.Threading.RateLimiting;
 
+ResourceManagerHack.OverrideComponentModelAnnotationsResourceManager();
+
 var builder = WebApplication.CreateBuilder(args);
 
 IConfiguration configuration = new ConfigurationBuilder()

--- a/Booker/Resources/DataAnnotations.cs
+++ b/Booker/Resources/DataAnnotations.cs
@@ -1,0 +1,6 @@
+namespace Booker
+{
+    public static class DataAnnotations
+    {
+    }
+}

--- a/Booker/Resources/DataAnnotations.resx
+++ b/Booker/Resources/DataAnnotations.resx
@@ -1,0 +1,246 @@
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AllowedValuesAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} nie jest równe żadnej z dozwolonych wartości.</value>
+  </data>
+  <data name="AssociatedMetadataTypeTypeDescriptor_MetadataTypeContainsUnknownProperties" xml:space="preserve">
+    <value>Skojarzony typ metadanych dla typu '{0}' zawiera następujące nieznane właściwości lub pola: {1}. Upewnij się, że nazwy tych elementów odpowiadają nazwom właściwości w głównym typie.</value>
+  </data>
+  <data name="AttributeStore_Unknown_Property" xml:space="preserve">
+    <value>Typ '{0}' nie zawiera publicznej właściwości o nazwie '{1}'.</value>
+  </data>
+  <data name="Base64StringAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} nie jest prawidłowym kodowaniem Base64.</value>
+  </data>
+  <data name="Common_PropertyNotFound" xml:space="preserve">
+    <value>Nie można odnaleźć właściwości {0}.{1}.</value>
+  </data>
+  <data name="CompareAttribute_MustMatch" xml:space="preserve">
+    <value>'{0}' i '{1}' nie są zgodne.</value>
+  </data>
+  <data name="CompareAttribute_UnknownProperty" xml:space="preserve">
+    <value>Nie można znaleźć właściwości o nazwie {0}.</value>
+  </data>
+  <data name="CreditCardAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} nie jest prawidłowym numerem karty kredytowej.</value>
+  </data>
+  <data name="CustomValidationAttribute_Method_Must_Return_ValidationResult" xml:space="preserve">
+    <value>Metoda CustomValidationAttribute '{0}' w typie '{1}' musi zwracać System.ComponentModel.DataAnnotations.ValidationResult. Użyj System.ComponentModel.DataAnnotations.ValidationResult.Success, aby oznaczyć sukces.</value>
+  </data>
+  <data name="CustomValidationAttribute_Method_Not_Found" xml:space="preserve">
+    <value>Metoda CustomValidationAttribute '{0}' nie istnieje w typie '{1}' lub nie jest publiczna i statyczna.</value>
+  </data>
+  <data name="CustomValidationAttribute_Method_Required" xml:space="preserve">
+    <value>Nie określono CustomValidationAttribute.Method.</value>
+  </data>
+  <data name="CustomValidationAttribute_Method_Signature" xml:space="preserve">
+    <value>Metoda CustomValidationAttribute '{0}' w typie '{1}' musi mieć następującą sygnaturę: public static ValidationResult {0}(object value, ValidationContext context). Parametr value może być silnie typowany. Parametr ValidationContext jest opcjonalny.</value>
+  </data>
+  <data name="CustomValidationAttribute_Type_Conversion_Failed" xml:space="preserve">
+    <value>Nie można przekonwertować wartości typu '{0}' na '{1}' zgodnie z oczekiwaniami metody {2}.{3}.</value>
+  </data>
+  <data name="CustomValidationAttribute_Type_Must_Be_Public" xml:space="preserve">
+    <value>Niestandardowy typ walidacji '{0}' musi być publiczny.</value>
+  </data>
+  <data name="CustomValidationAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} jest nieprawidłowe.</value>
+  </data>
+  <data name="CustomValidationAttribute_ValidatorType_Required" xml:space="preserve">
+    <value>Nie określono CustomValidationAttribute.ValidatorType.</value>
+  </data>
+  <data name="DataTypeAttribute_EmptyDataTypeString" xml:space="preserve">
+    <value>Niestandardowy ciąg DataType nie może być pusty ani mieć wartości null.</value>
+  </data>
+  <data name="DeniedValuesAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} jest równe jednej z wartości określonych w DeniedValuesAttribute.</value>
+  </data>
+  <data name="DisplayAttribute_PropertyNotSet" xml:space="preserve">
+    <value>Właściwość {0} nie została ustawiona. Użyj metody {1}, aby uzyskać wartość.</value>
+  </data>
+  <data name="EmailAddressAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} nie jest prawidłowym adresem e-mail.</value>
+  </data>
+  <data name="EnumDataTypeAttribute_TypeCannotBeNull" xml:space="preserve">
+    <value>Typ podany dla EnumDataTypeAttribute nie może być pusty.</value>
+  </data>
+  <data name="EnumDataTypeAttribute_TypeNeedsToBeAnEnum" xml:space="preserve">
+    <value>Typ '{0}' musi reprezentować typ wyliczeniowy.</value>
+  </data>
+  <data name="FileExtensionsAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} akceptuje tylko pliki z następującymi rozszerzeniami: {1}</value>
+  </data>
+  <data name="LocalizableString_LocalizationFailed" xml:space="preserve">
+    <value>Nie można pobrać właściwości '{0}' z powodu niepowodzenia lokalizacji. Typ '{1}' nie jest publiczny lub nie zawiera publicznej statycznej właściwości typu string o nazwie '{2}'.</value>
+  </data>
+  <data name="MaxLengthAttribute_InvalidMaxLength" xml:space="preserve">
+    <value>MaxLengthAttribute musi mieć wartość Length większą niż zero. Użyj MaxLength() bez parametrów, aby wskazać, że ciąg lub tablica może mieć maksymalną dozwoloną długość.</value>
+  </data>
+  <data name="MaxLengthAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} musi być napisem lub tablicą o maksymalnej długości '{1}'.</value>
+  </data>
+  <data name="MetadataTypeAttribute_TypeCannotBeNull" xml:space="preserve">
+    <value>MetadataClassType nie może być pusty.</value>
+  </data>
+  <data name="MinLengthAttribute_InvalidMinLength" xml:space="preserve">
+    <value>MinLengthAttribute musi mieć wartość Length równą zero lub większą.</value>
+  </data>
+  <data name="MinLengthAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} musi być napisem lub tablicą o minimalnej długości '{1}'.</value>
+  </data>
+  <data name="LengthAttribute_InvalidMinLength" xml:space="preserve">
+    <value>LengthAttribute musi mieć wartość MinimumLength równą zero lub większą.</value>
+  </data>
+  <data name="LengthAttribute_InvalidMaxLength" xml:space="preserve">
+    <value>LengthAttribute musi mieć wartość MaximumLength większą lub równą MinimumLength.</value>
+  </data>
+  <data name="LengthAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} musi być napisem lub kolekcją o minimalnej długości '{1}' i maksymalnej długości '{2}'.</value>
+  </data>
+  <data name="LengthAttribute_InvalidValueType" xml:space="preserve">
+    <value>Pole typu {0} musi być napisem, tablicą lub kolekcją.</value>
+  </data>
+  <data name="PhoneAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} nie jest prawidłowym numerem telefonu.</value>
+  </data>
+  <data name="RangeAttribute_ArbitraryTypeNotIComparable" xml:space="preserve">
+    <value>Typ {0} musi implementować {1}.</value>
+  </data>
+  <data name="RangeAttribute_MinGreaterThanMax" xml:space="preserve">
+    <value>Maksymalna wartość '{0}' musi być większa lub równa minimalnej wartości '{1}'.</value>
+  </data>
+  <data name="RangeAttribute_CannotUseExclusiveBoundsWhenTheyAreEqual" xml:space="preserve">
+    <value>Nie można używać otwartych przedziałów, gdy maksymalna wartość jest równa minimalnej wartości.</value>
+  </data>
+  <data name="RangeAttribute_Must_Set_Min_And_Max" xml:space="preserve">
+    <value>Należy ustawić wartości minimalne i maksymalne.</value>
+  </data>
+  <data name="RangeAttribute_Must_Set_Operand_Type" xml:space="preserve">
+    <value>OperandType musi być ustawiony, gdy do wartości minimalnych i maksymalnych używane są ciągi znaków.</value>
+  </data>
+  <data name="RangeAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} musi być pomiędzy {1} a {2} włącznie.</value>
+  </data>
+  <data name="RangeAttribute_ValidationError_MinExclusive" xml:space="preserve">
+    <value>Pole {0} musi być większe niż {1} i mniejsze lub równe {2}.</value>
+  </data>
+  <data name="RangeAttribute_ValidationError_MaxExclusive" xml:space="preserve">
+    <value>Pole {0} musi być większe lub równe {1} i mniejsze niż {2}.</value>
+  </data>
+  <data name="RangeAttribute_ValidationError_MinExclusive_MaxExclusive" xml:space="preserve">
+    <value>Pole {0} musi być większe niż {1} i mniejsze niż {2}.</value>
+  </data>
+  <data name="RegexAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} musi pasować do wyrażenia regularnego '{1}'.</value>
+  </data>
+  <data name="RegularExpressionAttribute_Empty_Pattern" xml:space="preserve">
+    <value>Wzorzec musi być ustawiony na prawidłowe wyrażenie regularne.</value>
+  </data>
+  <data name="RequiredAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} jest wymagane.</value>
+  </data>
+  <data name="StringLengthAttribute_InvalidMaxLength" xml:space="preserve">
+    <value>Maksymalna długość musi być nieujemną liczbą całkowitą.</value>
+  </data>
+  <data name="StringLengthAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} musi być ciągiem znaków o maksymalnej długości {1}.</value>
+  </data>
+  <data name="StringLengthAttribute_ValidationErrorIncludingMinimum" xml:space="preserve">
+    <value>Pole {0} musi być ciągiem znaków o minimalnej długości {2} i maksymalnej długości {1}.</value>
+  </data>
+  <data name="UIHintImplementation_ControlParameterKeyIsNotAString" xml:space="preserve">
+    <value>Parametr klucza na pozycji {0} o wartości '{1}' nie jest ciągiem znaków. Każdy kluczowy parametr kontrolny musi być ciągiem znaków.</value>
+  </data>
+  <data name="UIHintImplementation_ControlParameterKeyIsNull" xml:space="preserve">
+    <value>Parametr klucza na pozycji {0} jest pusty. Każdy kluczowy parametr kontrolny musi być ciągiem znaków.</value>
+  </data>
+  <data name="UIHintImplementation_ControlParameterKeyOccursMoreThanOnce" xml:space="preserve">
+    <value>Parametr klucza na pozycji {0} o wartości '{1}' występuje więcej niż raz.</value>
+  </data>
+  <data name="UIHintImplementation_NeedEvenNumberOfControlParameters" xml:space="preserve">
+    <value>Liczba parametrów kontrolnych musi być parzysta.</value>
+  </data>
+  <data name="UrlAttribute_Invalid" xml:space="preserve">
+    <value>Pole {0} nie jest prawidłowym, w pełni kwalifikowanym adresem URL http, https lub ftp.</value>
+  </data>
+  <data name="ValidationAttribute_Cannot_Set_ErrorMessage_And_Resource" xml:space="preserve">
+    <value>Należy ustawić ErrorMessageString lub ErrorMessageResourceName, ale nie oba jednocześnie.</value>
+  </data>
+  <data name="ValidationAttribute_IsValid_NotImplemented" xml:space="preserve">
+    <value>Metoda IsValid(object value) nie została zaimplementowana w tej klasie. Zalecanym punktem wejścia jest GetValidationResult(), a klasy powinny przesłonić IsValid(object value, ValidationContext context).</value>
+  </data>
+  <data name="ValidationAttribute_NeedBothResourceTypeAndResourceName" xml:space="preserve">
+    <value>Należy ustawić zarówno ErrorMessageResourceType, jak i ErrorMessageResourceName dla tego atrybutu.</value>
+  </data>
+  <data name="ValidationAttribute_ResourcePropertyNotStringType" xml:space="preserve">
+    <value>Właściwość '{0}' w typie zasobu '{1}' nie jest typu string.</value>
+  </data>
+  <data name="ValidationAttribute_ResourceTypeDoesNotHaveProperty" xml:space="preserve">
+    <value>Typ zasobu '{0}' nie ma dostępnej statycznej właściwości o nazwie '{1}'.</value>
+  </data>
+  <data name="ValidationAttribute_ValidationError" xml:space="preserve">
+    <value>Pole {0} jest nieprawidłowe.</value>
+  </data>
+  <data name="Validator_InstanceMustMatchValidationContextInstance" xml:space="preserve">
+    <value>Podany obiekt musi odpowiadać ObjectInstance w dostarczonym ValidationContext.</value>
+  </data>
+  <data name="Validator_Property_Value_Wrong_Type" xml:space="preserve">
+    <value>Wartość właściwości '{0}' musi być typu '{1}'.</value>
+  </data>
+</root>

--- a/Booker/Services/ResourceManagerHack.cs
+++ b/Booker/Services/ResourceManagerHack.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Resources;
+
+namespace Booker.Services;
+
+public static class ResourceManagerHack
+{
+    /// <summary>
+    /// If the server doesn't have .NET language packs installed then no matter what CurrentUICulture is set to, you'll always get English in 
+    /// DataAnnotations validation messages. Here we override DataAnnotationsResources to use a ResourceManager that uses language .resources 
+    /// files embedded in this assembly.
+    /// </summary>
+    public static void OverrideComponentModelAnnotationsResourceManager()
+    {
+        EnsureAssemblyIsLoaded();
+
+        FieldInfo? resourceManagerFieldInfo = GetResourceManagerFieldInfo();
+        ResourceManager resourceManager = GetNewResourceManager();
+        resourceManagerFieldInfo?.SetValue(null, resourceManager);
+    }
+
+    private static FieldInfo? GetResourceManagerFieldInfo()
+    {
+        var srAssembly = AppDomain.CurrentDomain
+                                  .GetAssemblies()
+                                  .First(assembly => assembly.FullName?.StartsWith("System.ComponentModel.Annotations,") ?? false);
+        var srType = srAssembly.GetType("System.SR");
+        return srType?.GetField("s_resourceManager", BindingFlags.Static | BindingFlags.NonPublic);
+    }
+    internal static ResourceManager GetNewResourceManager()
+    {
+        return new ResourceManager(typeof(DataAnnotations).ToString(), typeof(DataAnnotations).Assembly);
+    }
+    private static void EnsureAssemblyIsLoaded()
+    {
+        var _ = typeof(System.ComponentModel.DataAnnotations.RequiredAttribute);
+    }
+}


### PR DESCRIPTION
This fixes inaccurate translations in Identity. Additionally, it overrides the attribute error messages globally, so they don't have to be set on each attribute.

closes #77 