### PR TITLE
Fix: ItemManager reference equality and data tracking

### DIFF
--- a/Booker/Data/Book.cs
+++ b/Booker/Data/Book.cs
@@ -1,10 +1,12 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Configuration;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Booker.Data
 {
-    public class Book
-    {         
+    public class Book : IEquatable<Book>
+    {
         public int Id { get; set; }
         public required string Title { get; set; }
         public required ICollection<Grade> Grades { get; set; }
@@ -12,5 +14,28 @@ namespace Booker.Data
         public required Subject Subject { get; set; }
         public bool? Level { get; set; }
         public ICollection<Item> Items { get; } = new HashSet<Item>();
+
+
+
+        #region IEquatable
+
+        public bool Equals(Book? other)
+        {
+            if (other is null) return false;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as Book);
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public static bool operator ==(Book? left, Book? right)
+        {
+            if (left is null) return right is null;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Book? left, Book? right) => !(left == right);
+        
+        #endregion IEquatable
     }
 }

--- a/Booker/Data/Grade.cs
+++ b/Booker/Data/Grade.cs
@@ -1,10 +1,33 @@
 ﻿namespace Booker.Data
 {
-    public class Grade
+    public class Grade : IEquatable<Grade>
     {
         public int Id { get; set; }
         public required string GradeNumber { get; set; }
 
         public ICollection<Book> Books { get; } = new HashSet<Book>();
+
+
+
+        #region IEquatable
+
+        public bool Equals(Grade? other)
+        {
+            if (other is null) return false;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as Grade);
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public static bool operator ==(Grade? left, Grade? right)
+        {
+            if (left is null) return right is null;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Grade? left, Grade? right) => !(left == right);
+
+        #endregion IEquatable
     }
 }

--- a/Booker/Data/Subject.cs
+++ b/Booker/Data/Subject.cs
@@ -1,8 +1,28 @@
 ﻿namespace Booker.Data
 {
-    public class Subject
+    public class Subject : IEquatable<Subject>
     {
         public int Id { get; set; }
         public required string Name { get; set; }
+
+        #region IEquatable
+
+        public bool Equals(Subject? other)
+        {
+            if (other is null) return false;
+            return Id == other.Id;
+        }
+        public override bool Equals(object? obj) => Equals(obj as Subject);
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public static bool operator ==(Subject? left, Subject? right)
+        {
+            if (left is null) return right is null;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Subject? left, Subject? right) => !(left == right);
+
+        #endregion IEquatable
     }
 }

--- a/Booker/Pages/Edit.cshtml.cs
+++ b/Booker/Pages/Edit.cshtml.cs
@@ -102,7 +102,7 @@ namespace Booker.Pages
             using var stream = Input.Image?.OpenReadStream();
 
 
-            var result = await _itemManager.UpdateItemAsync(ItemToEdit.Id, new ItemManager.ItemModel(
+            var result = await _itemManager.UpdateItemAsync(ItemToEdit, new ItemManager.ItemModel(
                 user,
                 parameters,
                 Input.Description,

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -71,7 +71,7 @@ namespace Booker.Pages
 
             if (Request.Headers.ContainsKey("HX-Request"))
             {
-                return ViewComponent("ItemGalleryViewComponent", new
+                return ViewComponent("ItemGallery", new
                 {
                     itemIds = ItemIds,
                     parameters = Params,

--- a/Booker/Pages/Shared/BookFormModel.cs
+++ b/Booker/Pages/Shared/BookFormModel.cs
@@ -17,6 +17,7 @@ public abstract class BookFormModel<T> : PageModel, IBookForm where T : ItemInpu
     protected readonly ItemManager _itemManager;
     public bool IsFirstLoad { get; set; } = false;
 
+    [BindProperty]
     public T? Input { get; set; }
     ItemInputModel? IBookForm.Input => Input;
 

--- a/Booker/Pages/Shared/Components/ItemGallery/ItemGalleryViewComponent.cs
+++ b/Booker/Pages/Shared/Components/ItemGallery/ItemGalleryViewComponent.cs
@@ -1,6 +1,8 @@
 using Booker.Services;
 using Booker.Data;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+using Microsoft.AspNetCore.Html;
 
 namespace Booker.Pages.Shared.Components.ItemGallery;
 
@@ -35,7 +37,9 @@ public class ItemGalleryViewComponent : ViewComponent
     {
         if (!itemIds.Any())
         {
-            return Content("<p>Brak wyników...</p>");
+            return new HtmlContentViewComponentResult(
+                new HtmlString("<p>Brak wyników...</p>")
+            );
         }
 
         var itemsFromDb = await _itemManager.GetPagedItemsByIdsAsync(itemIds, pageNumber, pageSize).ToListAsync();


### PR DESCRIPTION
This fixes comparison by reference when adding or updating items which always failed validation. Additionally, it fixes data attachment to context (EF Core tried to insert duplicate data when data wasn't tracked properly).

closes #104